### PR TITLE
Update deprecated Stan array syntax

### DIFF
--- a/inst/stan/bdSampler.stan
+++ b/inst/stan/bdSampler.stan
@@ -1,5 +1,5 @@
 functions{
-  real logLikeBDcoalTimes_lpdf(real[] t, real lambda, real mu, real lgRho){
+  real logLikeBDcoalTimes_lpdf(array[] real t, real lambda, real mu, real lgRho){
     int numCoal;
     real ll;
     numCoal=size(t);
@@ -21,7 +21,7 @@ functions{
 
 data{
   int<lower=1> nCoal; // Number of coalescence times
-  real t[nCoal];  // Coalescence times
+  array[nCoal] real t;  // Coalescence times
   real upperLambda; // Max growth rate allowed
 }
 


### PR DESCRIPTION
This PR updates the syntax in your Stan models to use the new `array` syntax, otherwise your package will break with the next version of `rstan`. Thanks!